### PR TITLE
Supporting privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,8 @@ let package = Package(
     targets: [
         .target(
             name: "YMTGetDeviceName",
-            dependencies: []),
+            dependencies: [],
+            path: "Sources",
+            resources: [.copy("PrivacyInfo.xcprivacy")]),
     ]
 )

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/YMTGetDeviceName.podspec
+++ b/YMTGetDeviceName.podspec
@@ -16,5 +16,6 @@ s.source       = { :git => "https://github.com/MasamiYamate/YMTGetDeviceName.git
 s.platform     = :ios, "12.0"
 s.requires_arc = true
 s.source_files = 'Sources/**/*.{swift}'
+s.resource_bundles = { "YMTGetDeviceName" => ["Sources/PrivacyInfo.xcprivacy"] }
 s.swift_versions = ['5.0']
 end

--- a/YMTGetDeviceName.xcodeproj/project.pbxproj
+++ b/YMTGetDeviceName.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		944A88742873567500BE6B5A /* YMTGetDeviceName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944A88732873567500BE6B5A /* YMTGetDeviceName.swift */; };
 		944A88792873594F00BE6B5A /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 944A88782873594F00BE6B5A /* README.md */; };
 		944A887B2873595500BE6B5A /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 944A887A2873595500BE6B5A /* LICENSE */; };
+		C54F38242B72220D00D11F31 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = C54F38232B72220D00D11F31 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -17,6 +18,7 @@
 		944A88782873594F00BE6B5A /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		944A887A2873595500BE6B5A /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		948CF3C427D39F34001C91E7 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C54F38232B72220D00D11F31 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Sources/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D0B0413E2151ECEB001EB53D /* YMTGetDeviceName.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YMTGetDeviceName.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -49,6 +51,7 @@
 		D0B041342151ECEB001EB53D = {
 			isa = PBXGroup;
 			children = (
+				C54F38232B72220D00D11F31 /* PrivacyInfo.xcprivacy */,
 				944A887A2873595500BE6B5A /* LICENSE */,
 				944A88782873594F00BE6B5A /* README.md */,
 				944A88732873567500BE6B5A /* YMTGetDeviceName.swift */,
@@ -137,6 +140,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C54F38242B72220D00D11F31 /* PrivacyInfo.xcprivacy in Resources */,
 				944A887B2873595500BE6B5A /* LICENSE in Resources */,
 				944A88792873594F00BE6B5A /* README.md in Resources */,
 			);


### PR DESCRIPTION
### Description
This PR is for supporting [Privacy Manifests](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
I added `PrivacyInfo.xcprivacy` into the Project, and updated `Package.swift` and `podspec`.
(However, `s.version` in `podspec` is not changed.)

There is no error on `swift package describe` and `pod lib lint YMTGetDeviceName.podspec`.

Thank you.

### Description (ja)
これは`Privacy Manifests`に対応するためのプルリクです。
プロジェクトに`PrivacyInfo.xcprivacy`を追加し、`Package.swift` と `podspec`を更新しました。
(ただし、 `podspec`内の `s.version`は変更していません。)

`swift package describe` と `pod lib lint YMTGetDeviceName.podspec`を実行してエラーがありませんでした。

お役に立てば幸いです。