### PR TITLE
Add iPhone 17 series and new iPad models (2024-2025)

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/YMTGetDeviceName.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/YMTGetDeviceName.xcscheme
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "YMTGetDeviceName"
+               BuildableName = "YMTGetDeviceName"
+               BlueprintName = "YMTGetDeviceName"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "YMTGetDeviceNameTests"
+               BuildableName = "YMTGetDeviceNameTests"
+               BlueprintName = "YMTGetDeviceNameTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -14,5 +14,8 @@ let package = Package(
         .target(
             name: "YMTGetDeviceName",
             dependencies: []),
+        .testTarget(
+            name: "YMTGetDeviceNameTests",
+            dependencies: ["YMTGetDeviceName"]),
     ]
 )

--- a/Sources/YMTGetDeviceName/YMTGetDeviceName.swift
+++ b/Sources/YMTGetDeviceName/YMTGetDeviceName.swift
@@ -148,6 +148,14 @@ public class YMTGetDeviceName {
         case iPhone17_4 = "iPhone17,4"
         /// iPhone 16e
         case iPhone17_5 = "iPhone17,5"
+        /// iPhone 17
+        case iPhone18_3 = "iPhone18,3"
+        /// iPhone 17 Pro
+        case iPhone18_1 = "iPhone18,1"
+        /// iPhone 17 Pro Max
+        case iPhone18_2 = "iPhone18,2"
+        /// iPhone 17 Air
+        case iPhone18_4 = "iPhone18,4"
 
         // MARK: iPad
         /// iPad 1
@@ -328,6 +336,22 @@ public class YMTGetDeviceName {
         case iPad16_5 = "iPad16,5"
         /// iPad Pro 13inch M4 Cellular
         case iPad16_6 = "iPad16,6"
+        /// iPad mini 7th Generation WiFi
+        case iPad16_1 = "iPad16,1"
+        /// iPad mini 7th Generation Cellular
+        case iPad16_2 = "iPad16,2"
+        /// iPad Air 11inch M3 WiFi
+        case iPad15_3 = "iPad15,3"
+        /// iPad Air 11inch M3 Cellular
+        case iPad15_4 = "iPad15,4"
+        /// iPad Air 13inch M3 WiFi
+        case iPad15_5 = "iPad15,5"
+        /// iPad Air 13inch M3 Cellular
+        case iPad15_6 = "iPad15,6"
+        /// iPad 11th Generation WiFi
+        case iPad15_7 = "iPad15,7"
+        /// iPad 11th Generation Cellular
+        case iPad15_8 = "iPad15,8"
 
         /// device name
         func deviceName() -> String {
@@ -440,6 +464,14 @@ public class YMTGetDeviceName {
                 return "iPhone 16 Plus"
             case .iPhone17_5:
                 return "iPhone 16e"
+            case .iPhone18_3:
+                return "iPhone 17"
+            case .iPhone18_1:
+                return "iPhone 17 Pro"
+            case .iPhone18_2:
+                return "iPhone 17 Pro Max"
+            case .iPhone18_4:
+                return "iPhone 17 Air"
             case .iPad1_1:
                 return "iPad 1"
             case .iPad2_1, .iPad2_4:
@@ -580,6 +612,18 @@ public class YMTGetDeviceName {
                 return "iPad Pro 11 inch M4"
             case .iPad16_5, .iPad16_6:
                 return "iPad Pro 13 inch M4"
+            case .iPad16_1:
+                return "iPad mini 7th Generation WiFi"
+            case .iPad16_2:
+                return "iPad mini 7th Generation Cellular"
+            case .iPad15_3, .iPad15_4:
+                return "iPad Air 11 inch M3"
+            case .iPad15_5, .iPad15_6:
+                return "iPad Air 13 inch M3"
+            case .iPad15_7:
+                return "iPad 11th Generation WiFi"
+            case .iPad15_8:
+                return "iPad 11th Generation Cellular"
             }
         }
     }

--- a/Tests/YMTGetDeviceNameTests/YMTGetDeviceNameTests.swift
+++ b/Tests/YMTGetDeviceNameTests/YMTGetDeviceNameTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import YMTGetDeviceName
+
+final class YMTGetDeviceNameTests: XCTestCase {
+
+    // MARK: - iPhone Tests
+
+    func testIPhone17() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone18_3.deviceName(), "iPhone 17")
+    }
+
+    func testIPhone17Pro() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone18_1.deviceName(), "iPhone 17 Pro")
+    }
+
+    func testIPhone17ProMax() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone18_2.deviceName(), "iPhone 17 Pro Max")
+    }
+
+    func testIPhone17Air() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone18_4.deviceName(), "iPhone 17 Air")
+    }
+
+    func testIPhone16e() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone17_5.deviceName(), "iPhone 16e")
+    }
+
+    func testIPhone16() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone17_3.deviceName(), "iPhone 16")
+    }
+
+    func testIPhone16Plus() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone17_4.deviceName(), "iPhone 16 Plus")
+    }
+
+    func testIPhone16Pro() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone17_1.deviceName(), "iPhone 16 Pro")
+    }
+
+    func testIPhone16ProMax() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone17_2.deviceName(), "iPhone 16 Pro Max")
+    }
+
+    // MARK: - iPad mini Tests
+
+    func testIPadMini7WiFi() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad16_1.deviceName(), "iPad mini 7th Generation WiFi")
+    }
+
+    func testIPadMini7Cellular() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad16_2.deviceName(), "iPad mini 7th Generation Cellular")
+    }
+
+    // MARK: - iPad Air M3 Tests
+
+    func testIPadAir11InchM3WiFi() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad15_3.deviceName(), "iPad Air 11 inch M3")
+    }
+
+    func testIPadAir11InchM3Cellular() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad15_4.deviceName(), "iPad Air 11 inch M3")
+    }
+
+    func testIPadAir13InchM3WiFi() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad15_5.deviceName(), "iPad Air 13 inch M3")
+    }
+
+    func testIPadAir13InchM3Cellular() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad15_6.deviceName(), "iPad Air 13 inch M3")
+    }
+
+    // MARK: - iPad 11th Generation Tests
+
+    func testIPad11thGenWiFi() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad15_7.deviceName(), "iPad 11th Generation WiFi")
+    }
+
+    func testIPad11thGenCellular() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad15_8.deviceName(), "iPad 11th Generation Cellular")
+    }
+
+    // MARK: - iPad Pro M4 Tests
+
+    func testIPadPro11InchM4() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad16_3.deviceName(), "iPad Pro 11 inch M4")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad16_4.deviceName(), "iPad Pro 11 inch M4")
+    }
+
+    func testIPadPro13InchM4() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad16_5.deviceName(), "iPad Pro 13 inch M4")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad16_6.deviceName(), "iPad Pro 13 inch M4")
+    }
+
+    // MARK: - Simulator Tests
+
+    func testSimulator() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.i386.deviceName(), "Simulator")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.x86_64.deviceName(), "Simulator")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.arm64.deviceName(), "Simulator")
+    }
+
+    // MARK: - Device Code Raw Value Tests
+
+    func testDeviceCodeRawValues() {
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone18_1.rawValue, "iPhone18,1")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone18_2.rawValue, "iPhone18,2")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone18_3.rawValue, "iPhone18,3")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPhone18_4.rawValue, "iPhone18,4")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad16_1.rawValue, "iPad16,1")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad16_2.rawValue, "iPad16,2")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad15_3.rawValue, "iPad15,3")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad15_4.rawValue, "iPad15,4")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad15_5.rawValue, "iPad15,5")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad15_6.rawValue, "iPad15,6")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad15_7.rawValue, "iPad15,7")
+        XCTAssertEqual(YMTGetDeviceName.DeviceCode.iPad15_8.rawValue, "iPad15,8")
+    }
+}


### PR DESCRIPTION
## Summary
- Add iPhone 17 series: iPhone 17, iPhone 17 Pro, iPhone 17 Pro Max, iPhone 17 Air
- Add iPad mini 7th Generation (WiFi/Cellular)
- Add iPad Air M3 11-inch and 13-inch (WiFi/Cellular)
- Add iPad 11th Generation (WiFi/Cellular)
- Add unit tests for all new device codes (21 tests)
- Add test target and shared scheme for Xcode

## New Device Codes

### iPhone
| Code | Device |
|------|--------|
| iPhone18,1 | iPhone 17 Pro |
| iPhone18,2 | iPhone 17 Pro Max |
| iPhone18,3 | iPhone 17 |
| iPhone18,4 | iPhone 17 Air |

### iPad
| Code | Device |
|------|--------|
| iPad16,1 | iPad mini 7th Generation WiFi |
| iPad16,2 | iPad mini 7th Generation Cellular |
| iPad15,3/4 | iPad Air 11 inch M3 |
| iPad15,5/6 | iPad Air 13 inch M3 |
| iPad15,7 | iPad 11th Generation WiFi |
| iPad15,8 | iPad 11th Generation Cellular |

## Test plan
- [x] Run `swift build` - builds successfully
- [x] Run `swift test` - all 21 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)